### PR TITLE
fix install on kernels without module compression

### DIFF
--- a/ckms
+++ b/ckms
@@ -460,6 +460,7 @@ def get_compsfx():
     if opt_comp:
         return f".{opt_comp}"
     # figure out whether to compress modules
+    compsfx = ""
     for f in sorted((kern_path / opt_kernver).rglob("*.ko*")):
         if f.suffix in [".gz", ".xz", ".zst"]:
             compsfx = f.suffix


### PR DESCRIPTION
reproducible with `CONFIG_MODULE_COMPRESS` unset
```
base-kernel-0.2-r16.trigger: => ckms: built v4l2loopback=0.13.2 for 6.15.0-rc4-0-jg-qcom-x1e/aarch64
base-kernel-0.2-r16.trigger: Traceback (most recent call last):
base-kernel-0.2-r16.trigger:   File "/usr/sbin/ckms", line 949, in main
base-kernel-0.2-r16.trigger:     do_install(cmdline.command)
base-kernel-0.2-r16.trigger:     ~~~~~~~~~~^^^^^^^^^^^^^^^^^
base-kernel-0.2-r16.trigger:   File "/usr/sbin/ckms", line 638, in do_install
base-kernel-0.2-r16.trigger:     csfx = get_compsfx()
base-kernel-0.2-r16.trigger:   File "/usr/sbin/ckms", line 468, in get_compsfx
base-kernel-0.2-r16.trigger:     return compsfx
base-kernel-0.2-r16.trigger:            ^^^^^^^
base-kernel-0.2-r16.trigger: UnboundLocalError: cannot access local variable 'compsfx' where it is not associated with a value
base-kernel-0.2-r16.trigger: => ckms: installing v4l2loopback=0.13.2 for 6.15.0-rc4-0-jg-qcom-x1e/aarch64
base-kernel-0.2-r16.trigger: => ckms: ERROR: internal error
base-kernel-0.2-r16.trigger: FAILED: install v4l2loopback=0.13.2 for 6.15.0-rc4-0-jg-qcom-x1e
```